### PR TITLE
[fixes #11] Improve handling of empty secrets

### DIFF
--- a/pkg/cmd/modify_secret.go
+++ b/pkg/cmd/modify_secret.go
@@ -128,7 +128,7 @@ func (o *ModifySecretOptions) Run() error {
 	}
 	defer os.Remove(tempfile.Name())
 
-	yamlData, err := yaml.Marshal(data)
+	yamlData, err := yamlOrEmpty(data)
 	if err != nil {
 		return err
 	}
@@ -178,6 +178,16 @@ func (o *ModifySecretOptions) Run() error {
 	logrus.Infof("secret %q edited", o.secretName)
 
 	return nil
+}
+
+// yamlOrEmpty renders a map to a YAML, with the exception that an empty map
+// becomes an empty byte slice instead of []byte(`{}`)
+func yamlOrEmpty(data map[string]string) ([]byte, error) {
+	if len(data) == 0 {
+		return []byte{}, nil
+	}
+
+	return yaml.Marshal(data)
 }
 
 // getNamespace takes a set of kubectl flag values and returns the namespace we should be operating in

--- a/pkg/cmd/modify_secret.go
+++ b/pkg/cmd/modify_secret.go
@@ -27,7 +27,7 @@ type ModifySecretOptions struct {
 	IOStreams   genericclioptions.IOStreams
 
 	args         []string
-	kubeclient   *kubernetes.Clientset
+	kubeclient   kubernetes.Interface
 	secretName   string
 	namespace    string
 	printVersion bool

--- a/pkg/cmd/modify_secret_test.go
+++ b/pkg/cmd/modify_secret_test.go
@@ -84,3 +84,29 @@ func TestModifySecrets(t *testing.T) {
 		})
 	}
 }
+
+func TestYamlOrEmpty(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    map[string]string
+		expected []byte
+	}{
+		{
+			name:     "empty map",
+			input:    map[string]string{},
+			expected: []byte{},
+		}, {
+			name:     "populated map",
+			input:    map[string]string{"foo": "bar"},
+			expected: []byte("foo: bar\n"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := yamlOrEmpty(tc.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, output)
+		})
+	}
+}

--- a/pkg/cmd/modify_secret_test.go
+++ b/pkg/cmd/modify_secret_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestModifySecrets(t *testing.T) {
+	const (
+		name      = "mysecret"
+		namespace = "mynamespace"
+	)
+
+	logrus.SetOutput(ioutil.Discard)
+	origEditor := os.Getenv("EDITOR")
+	if origEditor != "" {
+		defer os.Setenv("EDITOR", origEditor)
+	} else {
+		defer os.Unsetenv("EDITOR")
+	}
+
+	testcases := []struct {
+		name     string
+		command  string
+		secret   map[string][]byte
+		expected map[string][]byte
+	}{
+		{
+			name:     "no changes to empty secret",
+			command:  "touch",
+			secret:   map[string][]byte{},
+			expected: map[string][]byte{},
+		}, {
+			name:     "no changes to populated secret",
+			command:  "touch",
+			secret:   map[string][]byte{"key": []byte("value")},
+			expected: map[string][]byte{"key": []byte("value")},
+		}, {
+			name:     "changes to populated secret",
+			command:  "sed -i= s/value/updated/",
+			secret:   map[string][]byte{"key": []byte("value")},
+			expected: map[string][]byte{"key": []byte("updated")},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("EDITOR", tc.command)
+
+			client := fake.NewSimpleClientset(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Namespace:   namespace,
+					Annotations: map[string]string{},
+				},
+				Data: tc.secret,
+			})
+
+			modify := ModifySecretOptions{
+				kubeclient: client,
+				secretName: name,
+				namespace:  namespace,
+			}
+			require.NoError(t, modify.Run())
+
+			object, err := client.Tracker().Get(
+				schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "secrets",
+				},
+				namespace, name,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, object.(*v1.Secret).Data)
+		})
+	}
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Get gets the secret from Kubernetes
-func Get(kubeclient *kubernetes.Clientset, name, namespace string) (*v1.Secret, error) {
+func Get(kubeclient kubernetes.Interface, name, namespace string) (*v1.Secret, error) {
 	return kubeclient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
 }
 
 // Update updates the secret to Kubernetes
-func Update(kubeclient *kubernetes.Clientset, secret *v1.Secret) (*v1.Secret, error) {
+func Update(kubeclient kubernetes.Interface, secret *v1.Secret) (*v1.Secret, error) {
 	return kubeclient.CoreV1().Secrets(secret.Namespace).Update(secret)
 }


### PR DESCRIPTION
Previously if you created an empty secret and then used `modify-secret`
to add data to it, you were presented with an empty JSON document, which
was confusing when you were expecting to write YAML:

    $ kubectl create secret generic dcarley
    secret/dcarley created
    $ EDITOR=cat kubectl modify-secret dcarley
    {}
    INFO[0000] no changes done to secret "dcarley"

This seems to be a "feature" of the YAML library when you marshal an
empty map:

- https://play.golang.org/p/9Byzr0yfQD3

Prevent this from happening by passing an empty byte slice (and thus
file) if the map is empty. The existing checksum continues to work since
we only checksum after writing `yamlData`.

I've pulled this out to a function so that it's easier to document and
test in isolation. It wasn't possible to test this with the round-trip
because we don't have a way to inspect the file in the middle of the
operation.

---

I've also included some round-trip tests in a separate commit that didn't turn out to be especially useful for this feature but seem useful in general.