### PR TITLE
fix: update release.yml for a newer version of Go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.16
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:


### PR DESCRIPTION
Fixes #19

When tag v0.0.41 was created, the [action failed](https://github.com/karlhaworth/kubectl-modify-secret/runs/4444573953?check_suite_focus=true)

On the building binaries step there's a message.

```
      • building binaries
29
         • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
```

I don't have your secrets so my action still failed however it looks like it built the darwin arm64 images. https://github.com/karlhaworth/kubectl-modify-secret/runs/4444573953?check_suite_focus=true

```
   • building binaries
63
      • building                  binary=/home/runner/work/kubectl-modify-secret/kubectl-modify-secret/dist/kubectl-modify-secret_linux_arm64/kubectl-modify-secret
64
      • building                  binary=/home/runner/work/kubectl-modify-secret/kubectl-modify-secret/dist/kubectl-modify-secret_linux_amd64/kubectl-modify-secret
65
      • building                  binary=/home/runner/work/kubectl-modify-secret/kubectl-modify-secret/dist/kubectl-modify-secret_darwin_amd64/kubectl-modify-secret
66
      • building                  binary=/home/runner/work/kubectl-modify-secret/kubectl-modify-secret/dist/kubectl-modify-secret_darwin_arm64/kubectl-modify-secret
67
   • archives         
68
      • creating                  archive=dist/kubectl-modify-secret_v0.0.42_darwin_arm64.tar.gz
69
      • creating                  archive=dist/kubectl-modify-secret_v0.0.42_linux_amd64.tar.gz
70
      • creating                  archive=dist/kubectl-modify-secret_v0.0.42_linux_arm64.tar.gz
71
      • creating                  archive=dist/kubectl-modify-secret_v0.0.42_darwin_amd64.tar.gz
72
   • calculating checksums
73
      • checksumming              file=kubectl-modify-secret_v0.0.42_darwin_amd64.tar.gz
74
      • checksumming              file=kubectl-modify-secret_v0.0.42_darwin_arm64.tar.gz
75
      • checksumming              file=kubectl-modify-secret_v0.0.42_linux_arm64.tar.gz
76
      • checksumming              file=kubectl-modify-secret_v0.0.42_linux_amd64.tar.gz
77
   • publishing       
78
      • scm releases     
79
         • creating or updating release repo=karlhaworth/kubectl-modify-secret tag=v0.0.42
80
         • release updated           url=v0.0.42 (release)
81
         • uploading to release      file=dist/kubectl-modify-secret_0.0.42_checksums.txt name=kubectl-modify-secret_0.0.42_checksums.txt
82
         • uploading to release      file=dist/kubectl-modify-secret_v0.0.42_darwin_arm64.tar.gz name=kubectl-modify-secret_v0.0.42_darwin_arm64.tar.gz
83
         • uploading to release      file=dist/kubectl-modify-secret_v0.0.42_linux_amd64.tar.gz name=kubectl-modify-secret_v0.0.42_linux_amd64.tar.gz
84
         • uploading to release      file=dist/kubectl-modify-secret_v0.0.42_linux_arm64.tar.gz name=kubectl-modify-secret_v0.0.42_linux_arm64.tar.gz
85
         • uploading to release      file=dist/kubectl-modify-secret_v0.0.42_darwin_amd64.tar.gz name=kubectl-modify-secret_v0.0.42_darwin_amd64.tar.gz
```