### PR TITLE
Update README.md: Add "install via brew".

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ This plugin pulls the secret from Kubernetes, and open the configured editor wit
 
 ![using kubectl-modify-secret plugin](demo/usage.gif)
 
-# Installing
+# Installing via krew
 - install `krew` using instructions [here](https://github.com/kubernetes-sigs/krew#installation)
 - run `kubectl krew update`
 - run `kubectl krew install modify-secret`
+
+# Install via brew
+- run `brew install rajatjindal/tap/modify-secret`
 
 ![installing kubectl-modify-secret plugin](demo/installation.gif)
 


### PR DESCRIPTION
I don't understand why `krew` exists.

There are already good package managers like `brew` (which works for Mac, Linux and WSL on Windows).

Please make people aware of `brew install rajatjindal/tap/modify-secret`.

Thank you.